### PR TITLE
Fixed not recognising synthetic enum constructor parameters. 

### DIFF
--- a/src/main/kotlin/org/parchmentmc/scribe/util/bytecode-utils.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/util/bytecode-utils.kt
@@ -10,13 +10,7 @@
 
 package org.parchmentmc.scribe.util
 
-import com.intellij.psi.PsiArrayType
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiClassType
-import com.intellij.psi.PsiField
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiPrimitiveType
-import com.intellij.psi.PsiType
+import com.intellij.psi.*
 import com.intellij.psi.util.TypeConversionUtil
 
 private const val INTERNAL_CONSTRUCTOR_NAME = "<init>"
@@ -98,6 +92,10 @@ val PsiMethod.descriptor: String?
 @Throws(ClassNameResolutionFailedException::class)
 private fun PsiMethod.appendDescriptor(builder: StringBuilder): StringBuilder {
     builder.append('(')
+    if (this.isEnumConstructor()) {
+        // Append fixed, synthetic parameters for Enum constructors.
+        builder.append("Ljava/lang/String;I")
+    }
     for (parameter in parameterList.parameters) {
         parameter.type.appendDescriptor(builder)
     }

--- a/src/main/kotlin/org/parchmentmc/scribe/util/bytecode-utils.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/util/bytecode-utils.kt
@@ -10,7 +10,13 @@
 
 package org.parchmentmc.scribe.util
 
-import com.intellij.psi.*
+import com.intellij.psi.PsiArrayType
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiType
 import com.intellij.psi.util.TypeConversionUtil
 
 private const val INTERNAL_CONSTRUCTOR_NAME = "<init>"

--- a/src/main/kotlin/org/parchmentmc/scribe/util/desc-index-utils.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/util/desc-index-utils.kt
@@ -35,9 +35,11 @@ val PsiParameter.jvmIndex: Byte
     }
 
 fun PsiMethod.getParameterByJvmIndex(jvmIndex: Byte): PsiParameter? {
-    return iterateJvmIndices { curIndex, curJvmIndex -> if (curJvmIndex == jvmIndex) {
-        this.parameterList.getParameter(curIndex - this.getParameterIndexOffset())
-    } else null }
+    return iterateJvmIndices { curIndex, curJvmIndex ->
+        if (curJvmIndex == jvmIndex) {
+            this.parameterList.getParameter(curIndex - this.getParameterIndexOffset())
+        } else null
+    }
 }
 
 private fun <T> PsiMethod.iterateJvmIndices(successFun: (Int, Byte) -> T?): T? {
@@ -66,13 +68,9 @@ private fun <T> PsiMethod.iterateJvmIndices(successFun: (Int, Byte) -> T?): T? {
     return null
 }
 
-fun PsiMethod.getParameterIndexOffset(): Int {
-    return when {
-        this.isEnumConstructor() -> 2
-        else -> 0
-    }
+fun PsiMethod.getParameterIndexOffset(): Int = when {
+    this.isEnumConstructor() -> 2
+    else -> 0
 }
 
-fun PsiMethod.isEnumConstructor(): Boolean {
-    return this.isConstructor && this.findContainingClass()?.isEnum == true
-}
+fun PsiMethod.isEnumConstructor(): Boolean = this.isConstructor && this.findContainingClass()?.isEnum == true


### PR DESCRIPTION
This PR fixes #1. This issue is explained in detail there with example. 

The fix simply adds the synthetic parameters to the descriptor and handles the offset indices accordingly. 

I have tested enum constructor hints and mapping parameter and Javadoc; all seems to be working with the fix. 