### PR TITLE
Automatically rename parameters when mapping

### DIFF
--- a/src/main/kotlin/org/parchmentmc/scribe/action/MapParameterAction.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/action/MapParameterAction.kt
@@ -31,9 +31,11 @@ import com.intellij.openapi.ui.InputValidatorEx
 import com.intellij.openapi.ui.Messages
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
+import com.intellij.refactoring.RefactoringFactory
 import com.intellij.ui.list.createTargetPopup
 import com.intellij.util.text.nullize
 import org.parchmentmc.scribe.ParchmentMappings
+import org.parchmentmc.scribe.settings.ParchmentProjectSettings
 import org.parchmentmc.scribe.util.findAllSuperConstructors
 import org.parchmentmc.scribe.util.findAllSuperMethods
 
@@ -58,6 +60,12 @@ class MapParameterAction : MappingAction() {
             parameterData.name = mapped
             mappings.modified = true
             ParchmentMappings.invalidateHints()
+
+            if (ParchmentProjectSettings.getInstance(project).renameAfterRemap) {
+                val factory = RefactoringFactory.getInstance(project);
+                val renameRefactoring = factory.createRename(parameter, mapped, false, false)
+                renameRefactoring.run()
+            }
         }
 
         mapParameter(e, parameter, mapFun)

--- a/src/main/kotlin/org/parchmentmc/scribe/action/MapParameterAction.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/action/MapParameterAction.kt
@@ -62,7 +62,12 @@ class MapParameterAction : MappingAction() {
             ParchmentMappings.invalidateHints()
 
             if (ParchmentProjectSettings.getInstance(project).renameAfterRemap) {
-                val factory = RefactoringFactory.getInstance(project);
+                val file = parameter.containingFile.virtualFile
+                if (file != null && !file.isWritable) {
+                    return
+                }
+
+                val factory = RefactoringFactory.getInstance(project)
                 val renameRefactoring = factory.createRename(parameter, mapped, false, false)
                 renameRefactoring.run()
             }

--- a/src/main/kotlin/org/parchmentmc/scribe/settings/ParchmentProjectConfigurable.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/settings/ParchmentProjectConfigurable.kt
@@ -82,6 +82,12 @@ class ParchmentProjectConfigurable(private val project: Project) : BoundConfigur
                 .bindSelected(settings::remapParameters)
                 .comment("Determines whether Scribe should automatically remap parameters when inserting constructors and overrides.")
         }
+
+        row {
+            checkBox("Rename Parameters When Remapping")
+                .bindSelected(settings::renameAfterRemap)
+                .comment("Determines whether Scribe should automatically rename parameters after they are remapped.")
+        }
     }
 
     override fun apply() {

--- a/src/main/kotlin/org/parchmentmc/scribe/settings/ParchmentProjectSettings.kt
+++ b/src/main/kotlin/org/parchmentmc/scribe/settings/ParchmentProjectSettings.kt
@@ -35,7 +35,8 @@ class ParchmentProjectSettings : PersistentStateComponent<ParchmentProjectSettin
     data class State(
         var mappingsPath: String = "",
         var displayHints: Boolean = true,
-        var remapParameters: Boolean = true
+        var remapParameters: Boolean = true,
+        var renameAfterRemap : Boolean = true
     )
 
     private var state = State()
@@ -70,6 +71,12 @@ class ParchmentProjectSettings : PersistentStateComponent<ParchmentProjectSettin
         get() = state.remapParameters
         set(value) {
             state.remapParameters = value
+        }
+
+    var renameAfterRemap: Boolean
+        get() = state.renameAfterRemap
+        set(value) {
+            state.renameAfterRemap = value
         }
 
     companion object {


### PR DESCRIPTION
Also adds a setting if you prefer the old behavior. Fixes #8 